### PR TITLE
Confirm 5.0.1 breaks the Tree api from 4.7.1 :

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation 'com.jakewharton.timber:timber:4.7.1'
+    implementation 'com.jakewharton.timber:timber:5.0.1'
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
 //    implementation 'com.github.TonyTangAndroid:ThreadTimber:0.1'

--- a/thread_timber/build.gradle
+++ b/thread_timber/build.gradle
@@ -28,7 +28,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.jakewharton.timber:timber:4.7.1'
+    implementation 'com.jakewharton.timber:timber:5.0.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'


### PR DESCRIPTION
>ThreadTree.java:43: error: method does not override or implement a method from a supertype
  @Override getTag